### PR TITLE
Fix timeline duplication bug

### DIFF
--- a/generator.js
+++ b/generator.js
@@ -1,8 +1,7 @@
 const moment = require('moment')
 
-const events = []
-
 const generator = (adapters) => {
+	const events = []
 	console.log('Generator init', adapters)
 	adapters.forEach(adapter => adapter().then(adapterEvents => {
 		adapterEvents.sort((a, b) => {


### PR DESCRIPTION
Fixes #5, the bug where items on the timeline get duplicated when calling /refresh

The issue was that the list was global, instead of resetting the list to the new values it pushed to the global array, duplicating data...